### PR TITLE
HUD에 현재 장착된 무기 표시

### DIFF
--- a/Source/BlackSpace/UI/BSPlayerHUDWidget.cpp
+++ b/Source/BlackSpace/UI/BSPlayerHUDWidget.cpp
@@ -2,8 +2,12 @@
 
 
 #include "UI/BSPlayerHUDWidget.h"
+
 #include "UI/BSStatBarWidget.h"
+#include "UI/BSPlayerStatusWeaponWidget.h"
 #include "Components/BSAttributeComponent.h"
+#include "Components/BSCombatComponent.h"
+#include "BSInventorySlot.h"
 
 UBSPlayerHUDWidget::UBSPlayerHUDWidget(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
 {
@@ -21,6 +25,12 @@ void UBSPlayerHUDWidget::NativeConstruct()
 			AttributeComp->BroadcastAttributeChanged(EAttributeType::Stamina);
 			AttributeComp->BroadcastAttributeChanged(EAttributeType::Health);
 		}
+
+		if (UBSCombatComponent* CombatComp = Player->GetComponentByClass<UBSCombatComponent>())
+		{
+			CombatComp->OnChangedMainWeapon.AddUObject(this, &ThisClass::SetMainWeaponState);
+			CombatComp->OnChangedSecondaryWeapon.AddUObject(this, &ThisClass::SetSecondaryWeaponState);
+		}
 	}
 }
 
@@ -35,4 +45,16 @@ void UBSPlayerHUDWidget::SetStatBarRatio(const EAttributeType& AttributeType, fl
 		HealthBarWidget->SetStatBarRatio(InRatio);
 		break;
 	}
+}
+
+void UBSPlayerHUDWidget::SetMainWeaponState(const FInventorySlot& MainWeaponInfo)
+{
+	MainWeaponWidget->SetWeaponImage(MainWeaponInfo.Image);
+	MainWeaponWidget->SetWeaponName(MainWeaponInfo.Name);
+}
+
+void UBSPlayerHUDWidget::SetSecondaryWeaponState(const FInventorySlot& SecondaryWeaponInfo)
+{
+	SecondaryWeaponWidget->SetWeaponImage(SecondaryWeaponInfo.Image);
+	SecondaryWeaponWidget->SetWeaponName(SecondaryWeaponInfo.Name);
 }

--- a/Source/BlackSpace/UI/BSPlayerHUDWidget.h
+++ b/Source/BlackSpace/UI/BSPlayerHUDWidget.h
@@ -8,6 +8,8 @@
 #include "BSPlayerHUDWidget.generated.h"
 
 class UBSStatBarWidget;
+class UBSPlayerStatusWeaponWidget;
+struct FInventorySlot;
 
 UCLASS()
 class BLACKSPACE_API UBSPlayerHUDWidget : public UUserWidget
@@ -21,6 +23,12 @@ protected:
 	UPROPERTY(meta = (BindWidget), BlueprintReadWrite)
 	TObjectPtr<UBSStatBarWidget> StaminaBarWidget;
 
+	UPROPERTY(meta = (BindWidget), BlueprintReadWrite)
+	TObjectPtr<UBSPlayerStatusWeaponWidget> MainWeaponWidget;
+
+	UPROPERTY(meta = (BindWidget), BlueprintReadWrite)
+	TObjectPtr<UBSPlayerStatusWeaponWidget> SecondaryWeaponWidget;
+
 public:
 	UBSPlayerHUDWidget(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
 
@@ -30,4 +38,9 @@ protected:
 
 public:
 	void SetStatBarRatio(const EAttributeType& AttributeType, float InRatio);
+
+protected:
+	void SetMainWeaponState(const FInventorySlot& MainWeaponInfo);
+	void SetSecondaryWeaponState(const FInventorySlot& SecondaryWeaponInfo);
+
 };


### PR DESCRIPTION
## 관련 이슈 번호

#24 HUD에 현재 장착된 무기 표시

<br>


## 작업 내용 요약
- 구현한 기능이나 수정한 내용을 서술합니다.

HUD에 현재 장착된 무기를 표시한다.

<br>


## 작업 상세 내용
- 주요 변경 사항과 설계 의도, 수정한 클래스나 시스템 구조에 대해 설명합니다.

Player Status 창에 표시하기 위한 무기 위젯이 이미 존재하므로, 이를 재활용했다.

<br>

Player HUD 클래스에 무기 위젯 멤버 변수를 두고 CombatComponent에서 무기가 교체될 때 호출되는 델리게이트에 연결했다.


<br>


## 변경 파일 요약
- 주요 변경 파일과 역할을 간략히 정리합니다.
- BSPlayerHUDWidget - 무기 Widget 멤버 변수 추가 및 델리게이트 등록용 함수 추가

<br>


## 궁금한 점 / 공부가 더 필요한 부분
- 작업 중 발생한 궁금한 점, 또는 이해가 잘 안되는 부분을 정리합니다.
