### PR TITLE
서서 죽는 버그 해결

### DIFF
--- a/Source/BlackSpace/Animation/AnimNotify_BSGetUp.cpp
+++ b/Source/BlackSpace/Animation/AnimNotify_BSGetUp.cpp
@@ -5,15 +5,27 @@
 #include "Animation/AnimInstance.h"
 #include "GameFramework/Character.h"
 
+#include "Components/BSStateComponent.h"
+#include "BSGameplayTag.h"
+
 void UAnimNotify_BSGetUp::Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, const FAnimNotifyEventReference& EventReference)
 {
 	Super::Notify(MeshComp, Animation, EventReference);
 
-	if (ACharacter* OwnerCharacter = Cast<ACharacter>(MeshComp->GetOwner()))
+	if (AActor* OwnerActor = MeshComp->GetOwner())
 	{
-		if (UAnimInstance* Anim = OwnerCharacter->GetMesh()->GetAnimInstance())
+		if (ACharacter* OwnerCharacter = Cast<ACharacter>(OwnerActor))
 		{
-			Anim->Montage_Play(GetUpMontage);
+			UBSStateComponent* StateComp = OwnerCharacter->GetComponentByClass<UBSStateComponent>();
+			check(StateComp);
+
+			if (StateComp->IsCurrentStateEqualToIt(BSGameplayTag::Character_State_Death) == false)
+			{
+				if (UAnimInstance* Anim = OwnerCharacter->GetMesh()->GetAnimInstance())
+				{
+					Anim->Montage_Play(GetUpMontage);
+				}
+			}
 		}
 	}
 }

--- a/Source/BlackSpace/BSGameplayTag.cpp
+++ b/Source/BlackSpace/BSGameplayTag.cpp
@@ -17,6 +17,7 @@ namespace BSGameplayTag
 	UE_DEFINE_GAMEPLAY_TAG(Character_State_BackAttacked, "Character.State.BackAttacked");
 	UE_DEFINE_GAMEPLAY_TAG(Character_State_Stunned, "Character.State.Stunned");
 	UE_DEFINE_GAMEPLAY_TAG(Character_State_MaxPosture, "Character.State.MaxPosture");
+	UE_DEFINE_GAMEPLAY_TAG(Character_State_MaxPostureAttacked, "Character.State.MaxPostureAttacked");
 
 	UE_DEFINE_GAMEPLAY_TAG(Character_Action_Equip, "Character.Action.Equip");
 	UE_DEFINE_GAMEPLAY_TAG(Character_Action_Unequip, "Character.Action.Unequip");

--- a/Source/BlackSpace/BSGameplayTag.h
+++ b/Source/BlackSpace/BSGameplayTag.h
@@ -18,6 +18,7 @@ namespace BSGameplayTag
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(Character_State_BackAttacked);
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(Character_State_Stunned);
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(Character_State_MaxPosture);
+	UE_DECLARE_GAMEPLAY_TAG_EXTERN(Character_State_MaxPostureAttacked);
 	
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(Character_Action_Equip);
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(Character_Action_Unequip);

--- a/Source/BlackSpace/Characters/BSCharacterEnemy.cpp
+++ b/Source/BlackSpace/Characters/BSCharacterEnemy.cpp
@@ -302,6 +302,9 @@ void ABSCharacterEnemy::TogglePostureAttackWidgetVisibility(const bool bShouldPo
 void ABSCharacterEnemy::PostureAttacked(UAnimMontage* PostureAttackReactionMontage)
 {
 	check(AttributeComp);
+	check(StateComp);
+
+	StateComp->SetState(BSGameplayTag::Character_State_MaxPostureAttacked);
 
 	StopAnimMontage();
 
@@ -358,7 +361,7 @@ void ABSCharacterEnemy::OnDeath()
 
 	FGameplayTagContainer CheckTags;
 	CheckTags.AddTag(BSGameplayTag::Character_State_BackAttacked);
-	CheckTags.AddTag(BSGameplayTag::Character_State_MaxPosture);
+	CheckTags.AddTag(BSGameplayTag::Character_State_MaxPostureAttacked);
 
 	if (!StateComp->IsCurrentStateEqualToAny(CheckTags))
 	{
@@ -399,6 +402,8 @@ void ABSCharacterEnemy::SetDeathState()
 	}
 
 	ToggleHealthBarVisibility(false);
+	ToggleBackAttackWidgetVisibility(false);
+	TogglePostureAttackWidgetVisibility(false);
 
 	FTimerHandle DeathTimer;
 	GetWorld()->GetTimerManager().SetTimer(DeathTimer, [this]()


### PR DESCRIPTION
## 관련 이슈 번호

#32 일반 적의 죽음

<br>


## 작업 내용 요약
- 구현한 기능이나 수정한 내용을 서술합니다.

상태를 하나 더 만들어 예외에 걸리지 않도록 했다.

<br>


## 작업 상세 내용
- 주요 변경 사항과 설계 의도, 수정한 클래스나 시스템 구조에 대해 설명합니다.

체간 공격을 당하는 상태를 하나 더 만들었다.
```
UE_DEFINE_GAMEPLAY_TAG(Character_State_MaxPostureAttacked, "Character.State.MaxPostureAttacked");
```

<br>

체간 공격을 당할 때 상태를 변경한다.
```
void ABSCharacterEnemy::PostureAttacked(UAnimMontage* PostureAttackReactionMontage)
{
	...

	StateComp->SetState(BSGameplayTag::Character_State_MaxPostureAttacked);

	...
}
```

<br>

체간 공격을 당한 뒤, 일어나는 애니메이션이 Notify로 실행된다. 
죽음 상태를 체크해서 체력이 다한 적이 일어나는 모션을 취하지 않도록 한다.
```
if (AActor* OwnerActor = MeshComp->GetOwner())
{
	if (ACharacter* OwnerCharacter = Cast<ACharacter>(OwnerActor))
	{
		UBSStateComponent* StateComp = OwnerCharacter->GetComponentByClass<UBSStateComponent>();
		check(StateComp);

		if (StateComp->IsCurrentStateEqualToIt(BSGameplayTag::Character_State_Death) == false)
		{
			if (UAnimInstance* Anim = OwnerCharacter->GetMesh()->GetAnimInstance())
			{
				Anim->Montage_Play(GetUpMontage);
			}
		}
	}
}
```

<br>


## 변경 파일 요약
- 주요 변경 파일과 역할을 간략히 정리합니다.
- BSGameplayTag : 상태 추가
- BSCharacterEnemy : 상태 변경 추가
- Notify_GetUp : 예외 추가

<br>


## 궁금한 점 / 공부가 더 필요한 부분
- 작업 중 발생한 궁금한 점, 또는 이해가 잘 안되는 부분을 정리합니다.
