### PR TITLE
대미지 UI 표시

### DIFF
--- a/Source/BlackSpace/AI/Controller/BSEnemyAIController.cpp
+++ b/Source/BlackSpace/AI/Controller/BSEnemyAIController.cpp
@@ -84,6 +84,10 @@ void ABSEnemyAIController::UpdateTarget() const
 	else
 	{
 		SetTarget(nullptr);
+		if (!IsDetectedPlayer())
+		{
+			ControlledEnemy->SeesTarget(nullptr);
+		}
 		ControlledEnemy->ToggleHealthBarVisibility(false);
 	}
 

--- a/Source/BlackSpace/BlackSpace.Build.cs
+++ b/Source/BlackSpace/BlackSpace.Build.cs
@@ -20,7 +20,8 @@ public class BlackSpace : ModuleRules
             "AnimGraphRuntime",
             "MotionWarping",
             "Niagara",
-			"NavigationSystem"
+			"NavigationSystem",
+			"SlateCore"
         });
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });

--- a/Source/BlackSpace/Characters/BSCharacterEnemy.cpp
+++ b/Source/BlackSpace/Characters/BSCharacterEnemy.cpp
@@ -22,8 +22,9 @@
 #include "Equipments/BSWeapon.h"
 #include "Items/BSPickupItem.h"
 #include "UI/BSStatBarWidget.h"
-#include "BSDefine.h"
+#include "GameModes/BSDamageNumberSubsystem.h"
 #include "BSGameplayTag.h"
+#include "BSDefine.h"
 
 ABSCharacterEnemy::ABSCharacterEnemy()
 {
@@ -132,6 +133,11 @@ float ABSCharacterEnemy::TakeDamage(float DamageAmount, FDamageEvent const& Dama
 	if (bTakeDamageUsage)
 	{
 		AttributeComp->TakeDamageAmount(ActualDamage);
+
+		if (UBSDamageNumberSubsystem* Subsystem = GetWorld()->GetSubsystem<UBSDamageNumberSubsystem>())
+		{
+			Subsystem->AddDamageAtSocket(GetMesh(), FName(TEXT("DamageSocket")), ActualDamage, FVector(0.f, 0.f, 15.f), 1.f);
+		}
 
 		if (!IsEnabledPostureAttack() && !IsBlockingState())
 		{

--- a/Source/BlackSpace/Characters/BSCharacterEnemy.cpp
+++ b/Source/BlackSpace/Characters/BSCharacterEnemy.cpp
@@ -120,6 +120,7 @@ float ABSCharacterEnemy::TakeDamage(float DamageAmount, FDamageEvent const& Dama
 	float ActualDamage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
 
 	check(AttributeComp);
+	ActualDamage = ActualDamage - FMath::RandRange(0, AttributeComp->GetDefense());
 
 	// 대치 중인가
 	const bool bFacing = UKismetMathLibrary::InRange_FloatFloat(GetDotProductTo(EventInstigator->GetPawn()), -0.1f, 1.f);
@@ -342,9 +343,13 @@ bool ABSCharacterEnemy::CanBeTargeted()
 void ABSCharacterEnemy::SeesTarget(AActor* InTargetActor)
 {
 	// AIController 에서 호출하기 위한 가상함수
-	if (bUnstoppable)
+	if (bUnstoppable && InTargetActor != nullptr)
 	{
 		GetMesh()->SetOverlayMaterial(OutlineMaterial);
+	}
+	else
+	{
+		GetMesh()->SetOverlayMaterial(nullptr);
 	}
 }
 

--- a/Source/BlackSpace/Characters/BSCharacterEnemyKnight.cpp
+++ b/Source/BlackSpace/Characters/BSCharacterEnemyKnight.cpp
@@ -132,10 +132,10 @@ void ABSCharacterEnemyKnight::PostureAttacked(UAnimMontage* PostureAttackReactio
 
 void ABSCharacterEnemyKnight::LoadBodyMeshMaterial() const
 {
-	UMaterialInterface* ArmMat = LoadObject<UMaterialInterface>(nullptr, TEXT("/Script/Engine.MaterialInstanceConstant'/Game/_Assets/DF_DRAGON_KNIGHT/MATERIALS/INSTANCES/Fire/MI_DK_Arms_fire.MI_DK_Arms_fire'"));
-	UMaterialInterface* BodyMat = LoadObject<UMaterialInterface>(nullptr, TEXT("/Script/Engine.MaterialInstanceConstant'/Game/_Assets/DF_DRAGON_KNIGHT/MATERIALS/INSTANCES/Fire/MI_DK_Body_Fire.MI_DK_Body_Fire'"));
-	UMaterialInterface* ClothMat = LoadObject<UMaterialInterface>(nullptr, TEXT("/Script/Engine.MaterialInstanceConstant'/Game/_Assets/DF_DRAGON_KNIGHT/MATERIALS/INSTANCES/Fire/MI_DK_Cloth_Fire.MI_DK_Cloth_Fire'"));
-	UMaterialInterface* SwordMat = LoadObject<UMaterialInterface>(nullptr, TEXT("/Script/Engine.MaterialInstanceConstant'/Game/_Assets/DF_DRAGON_KNIGHT/MATERIALS/INSTANCES/Fire/MI_DK_Sword_Fire.MI_DK_Sword_Fire'"));
+	UMaterialInterface* ArmMat = LoadObject<UMaterialInterface>(nullptr, TEXT("/Script/Engine.MaterialInstanceConstant'/Game/_Assets/DF_DRAGON_KNIGHT/MATERIALS2/INSTANCES/Fire/MI_DK_Arms_fire.MI_DK_Arms_fire'"));
+	UMaterialInterface* BodyMat = LoadObject<UMaterialInterface>(nullptr, TEXT("/Script/Engine.MaterialInstanceConstant'/Game/_Assets/DF_DRAGON_KNIGHT/MATERIALS2/INSTANCES/Fire/MI_DK_Body_Fire.MI_DK_Body_Fire'"));
+	UMaterialInterface* ClothMat = LoadObject<UMaterialInterface>(nullptr, TEXT("/Script/Engine.MaterialInstanceConstant'/Game/_Assets/DF_DRAGON_KNIGHT/MATERIALS2/INSTANCES/Fire/MI_DK_Cloth_Fire.MI_DK_Cloth_Fire'"));
+	UMaterialInterface* SwordMat = LoadObject<UMaterialInterface>(nullptr, TEXT("/Script/Engine.MaterialInstanceConstant'/Game/_Assets/DF_DRAGON_KNIGHT/MATERIALS2/INSTANCES/Fire/MI_DK_Sword_Fire.MI_DK_Sword_Fire'"));
 
 	if (GetMesh())
 	{

--- a/Source/BlackSpace/Components/BSAttributeComponent.h
+++ b/Source/BlackSpace/Components/BSAttributeComponent.h
@@ -54,6 +54,9 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Stat")
 	float RegenPostureRate = 1.f;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Stat")
+	int32 Defense = 1.f;
+
 	FTimerHandle StaminaRegenTimer;
 	FTimerHandle PostureRegenTimer;
 
@@ -79,6 +82,8 @@ public:
 	FORCEINLINE float GetMaxPosture() const { return MaxPosture; }
 	FORCEINLINE float GetBasePosture() const { return BasePosture; }
 	FORCEINLINE float GetPostureRatio() const { return BasePosture / MaxPosture; }
+
+	FORCEINLINE int32 GetDefense() const { return Defense; }
 
 public:
 	bool CheckHasEnoughStamina(float StaminaCost) const;

--- a/Source/BlackSpace/GameModes/BSDamageNumberSubsystem.cpp
+++ b/Source/BlackSpace/GameModes/BSDamageNumberSubsystem.cpp
@@ -1,0 +1,192 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GameModes/BSDamageNumberSubsystem.h"
+#include "Blueprint/WidgetLayoutLibrary.h"
+#include "Kismet/GameplayStatics.h"
+#include "GameFramework/PlayerController.h"
+#include "Engine/World.h"
+
+#include "UI/BSDamageNumberRootWidget.h"
+
+
+UBSDamageNumberSubsystem::UBSDamageNumberSubsystem()
+{
+    static ConstructorHelpers::FClassFinder<UBSDamageNumberRootWidget> RootWidgetClassRef(TEXT("/Game/_Game/UI/Damage/WBP_DamageNumberRoot.WBP_DamageNumberRoot_C"));
+    if (RootWidgetClassRef.Succeeded())
+    {
+        RootWidgetClass = RootWidgetClassRef.Class;
+    }
+}
+
+void UBSDamageNumberSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+    Super::Initialize(Collection);
+
+    EnsureRootWidget();
+}
+
+void UBSDamageNumberSubsystem::Deinitialize()
+{
+    if (RootWidget)
+    {
+        RootWidget->RemoveFromParent();
+        RootWidget = nullptr;
+    }
+
+    Active.Reset();
+
+    Super::Deinitialize();
+}
+
+void UBSDamageNumberSubsystem::Tick(float DeltaTime)
+{
+    EnsureRootWidget();
+
+    if (!RootWidget || Active.Num() == 0) 
+    { 
+        return; 
+    }
+
+    for (int32 i = Active.Num() - 1; i >= 0; --i)
+    {
+        UpdateItem(i, DeltaTime);
+    }
+}
+
+void UBSDamageNumberSubsystem::AddDamage(const FVector& InWorldLoc, float InDamage, float LifeTime)
+{
+    EnsureRootWidget();
+    if (!RootWidget) return; 
+
+    FDamageItem Item;
+    Item.WorldLoc = InWorldLoc;
+    Item.Damage = InDamage;
+    Item.Life = FMath::Max(0.1f, LifeTime);
+    Item.Elapsed = 0.f;
+    Item.PoolIndex = RootWidget->BorrowEntry(FText::AsNumber(FMath::RoundToInt(InDamage)));
+    Active.Add(Item);
+}
+
+void UBSDamageNumberSubsystem::AddDamageAtActor(AActor* Target, float InDamage, FVector LocalOffset, float LifeTime)
+{
+    EnsureRootWidget();
+    if (!RootWidget || !Target) return;
+
+    FDamageItem Item;
+    Item.TargetActor = Target;
+    Item.LocalOffset = LocalOffset;
+    Item.WorldLoc = Target->GetActorLocation() + LocalOffset; // 초기값
+    Item.Damage = InDamage;
+    Item.Life = FMath::Max(0.1f, LifeTime);
+    Item.PoolIndex = RootWidget->BorrowEntry(FText::AsNumber(FMath::RoundToInt(InDamage)));
+    Active.Add(Item);
+}
+
+void UBSDamageNumberSubsystem::AddDamageAtSocket(USkeletalMeshComponent* Mesh, FName Socket, float InDamage, FVector LocalOffset, float LifeTime)
+{
+    EnsureRootWidget();
+    if (!RootWidget || !Mesh) return;
+
+    FDamageItem Item;
+    Item.TargetMesh = Mesh;
+    Item.TargetSocket = Socket;
+    Item.LocalOffset = LocalOffset;
+    Item.WorldLoc = Mesh->DoesSocketExist(Socket) ? Mesh->GetSocketLocation(Socket) + LocalOffset : Mesh->GetComponentLocation() + LocalOffset;
+    Item.Damage = InDamage;
+    Item.Life = FMath::Max(0.1f, LifeTime);
+    Item.PoolIndex = RootWidget->BorrowEntry(FText::AsNumber(FMath::RoundToInt(InDamage)));
+    Active.Add(Item);
+}
+
+void UBSDamageNumberSubsystem::EnsureRootWidget()
+{
+    if (RootWidget || !GetWorld() || !RootWidgetClass) 
+    { 
+        return; 
+    }
+
+    APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
+    if (!PC) 
+    { 
+        return; 
+    }
+
+    RootWidget = CreateWidget<UBSDamageNumberRootWidget>(PC, RootWidgetClass);
+    if (RootWidget)
+    {
+        RootWidget->AddToViewport(10);   // ZOrder 넉넉히
+        RootWidget->InitPool(64);        // 풀 초기 크기 (프로젝트에 맞게 조정)
+    }
+}
+
+void UBSDamageNumberSubsystem::UpdateItem(int32 Index, float DeltaTime)
+{
+    FDamageItem& DamageItem = Active[Index];
+    DamageItem.Elapsed += DeltaTime;
+    const float T = FMath::Clamp(DamageItem.Elapsed / DamageItem.Life, 0.f, 1.f);
+
+    // 타겟 추적(있으면 우선)
+    if (DamageItem.TargetMesh.IsValid())
+    {
+        if (DamageItem.TargetSocket != NAME_None && DamageItem.TargetMesh->DoesSocketExist(DamageItem.TargetSocket))
+        {
+            DamageItem.WorldLoc = DamageItem.TargetMesh->GetSocketLocation(DamageItem.TargetSocket) + DamageItem.LocalOffset;
+        }
+        else
+        {
+            DamageItem.WorldLoc = DamageItem.TargetMesh->GetComponentLocation() + DamageItem.LocalOffset;
+        }
+    }
+    else if (DamageItem.TargetActor.IsValid())
+    {
+        DamageItem.WorldLoc = DamageItem.TargetActor->GetActorLocation() + DamageItem.LocalOffset;
+    }
+
+    // 타겟 모두 소멸 시 조기 반환
+    if (!DamageItem.TargetActor.IsValid() && !DamageItem.TargetMesh.IsValid() && DamageItem.PoolIndex != INDEX_NONE)
+    {
+        RootWidget->ReturnEntry(DamageItem.PoolIndex);
+        Active.RemoveAtSwap(Index);
+        return;
+    }
+
+    APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
+    if (!PC) return;
+
+    // 간단한 상승/흔들림
+    const float Up = FMath::Lerp(0.f, 40.f, T);
+    const float Sway = FMath::Sin(DamageItem.Elapsed * 12.f) * 6.f;
+    const FVector World = DamageItem.WorldLoc + FVector(0, Sway, Up);
+
+    // 화면 좌표 투영
+    FVector2D ScreenPos;
+    const bool bOnScreen = UWidgetLayoutLibrary::ProjectWorldLocationToWidgetPosition(PC, World, ScreenPos, false);
+
+    // 오클루전(선택)
+    bool bVisible = bOnScreen;
+    if (bUseOcclusionCheck && bOnScreen)
+    {
+        FHitResult Hit;
+        FCollisionQueryParams Params(SCENE_QUERY_STAT(DamageNumberOcclusion), /*bTraceComplex=*/true);
+        if (APawn* Pawn = PC->GetPawn()) { Params.AddIgnoredActor(Pawn); }
+        const FVector CamLoc = PC->PlayerCameraManager->GetCameraLocation();
+        const bool bBlocked = GetWorld()->LineTraceSingleByChannel(Hit, CamLoc, World, ECC_Visibility, Params);
+        bVisible = !bBlocked || (Hit.GetActor() == DamageItem.TargetActor.Get());
+    }
+
+    // 알파/스케일
+    const float Alpha = 1.f - T;
+    const float Scale = 1.f + 0.15f * FMath::Sin(T * PI);
+
+    if (DamageItem.PoolIndex != INDEX_NONE)
+    {
+        RootWidget->UpdateEntry(DamageItem.PoolIndex, ScreenPos, Alpha, Scale, bVisible);
+    }
+
+    if (DamageItem.Elapsed >= DamageItem.Life || !bOnScreen)
+    {
+        RootWidget->ReturnEntry(DamageItem.PoolIndex);
+        Active.RemoveAtSwap(Index);
+    }
+}

--- a/Source/BlackSpace/GameModes/BSDamageNumberSubsystem.h
+++ b/Source/BlackSpace/GameModes/BSDamageNumberSubsystem.h
@@ -41,7 +41,6 @@ protected:
     UPROPERTY()
     TObjectPtr<UBSDamageNumberRootWidget> RootWidget;
 
-    /** 에디터/런타임에서 대체 가능(없으면 /Game/UI/WBP_DamageNumberRoot 를 찾음) */
     UPROPERTY(EditDefaultsOnly, Category = "DamageNumber | UI")
     TSubclassOf<UBSDamageNumberRootWidget> RootWidgetClass;
 

--- a/Source/BlackSpace/GameModes/BSDamageNumberSubsystem.h
+++ b/Source/BlackSpace/GameModes/BSDamageNumberSubsystem.h
@@ -1,0 +1,79 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/WorldSubsystem.h"
+#include "BSDamageNumberSubsystem.generated.h"
+
+class UBSDamageNumberRootWidget;
+
+USTRUCT()
+struct FDamageItem
+{
+    GENERATED_BODY()
+
+    /** 마지막으로 계산된 월드 위치(투영용). Target이 유효하면 매 프레임 갱신됨 */
+    FVector WorldLoc = FVector::ZeroVector;
+
+    /** 타겟 추적(액터/메시/소켓) */
+    TWeakObjectPtr<AActor> TargetActor;
+    TWeakObjectPtr<USkeletalMeshComponent> TargetMesh;
+    FName TargetSocket = NAME_None;
+    FVector LocalOffset = FVector::ZeroVector;
+
+    /** 연출 파라미터 */
+    float Damage = 0.f;
+    float Life = 1.0f;
+    float Elapsed = 0.f;
+
+    /** 풀에서 빌린 인덱스 */
+    int32 PoolIndex = INDEX_NONE;
+};
+
+UCLASS()
+class BLACKSPACE_API UBSDamageNumberSubsystem : public UTickableWorldSubsystem
+{
+	GENERATED_BODY()
+
+protected:
+    /** 뷰포트에 1장 올라가는 루트 위젯 */
+    UPROPERTY()
+    TObjectPtr<UBSDamageNumberRootWidget> RootWidget;
+
+    /** 에디터/런타임에서 대체 가능(없으면 /Game/UI/WBP_DamageNumberRoot 를 찾음) */
+    UPROPERTY(EditDefaultsOnly, Category = "DamageNumber | UI")
+    TSubclassOf<UBSDamageNumberRootWidget> RootWidgetClass;
+
+    /** 활성 아이템 배열 */
+    UPROPERTY()
+    TArray<FDamageItem> Active;
+
+protected:
+    /** 오클루전(가려짐) 체크 사용 여부 */
+    UPROPERTY(EditAnywhere, Category = "DamageNumber | Visibility")
+    bool bUseOcclusionCheck = false;
+
+public:
+    UBSDamageNumberSubsystem();
+
+    // UTickableWorldSubsystem
+    virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+    virtual void Deinitialize() override;
+    virtual void Tick(float DeltaTime) override;
+    virtual TStatId GetStatId() const override { RETURN_QUICK_DECLARE_CYCLE_STAT(UDamageNumberSubsystem, STATGROUP_Tickables); }
+
+    /** 고정 좌표에 데미지 숫자 추가 */
+    void AddDamage(const FVector& InWorldLoc, float InDamage, float LifeTime = 1.0f);
+
+    /** 액터 머리 위(로컬 오프셋 포함)에 데미지 숫자 추가 */
+    void AddDamageAtActor(AActor* Target, float InDamage, FVector LocalOffset = FVector(0, 0, 90.f), float LifeTime = 1.0f);
+
+    /** 스켈레탈 메시 소켓 위치에 데미지 숫자 추가 */
+    void AddDamageAtSocket(USkeletalMeshComponent* Mesh, FName Socket, float InDamage, FVector LocalOffset = FVector(0, 0, 20.f), float LifeTime = 1.0f);
+
+private:
+    void EnsureRootWidget();
+    void UpdateItem(int32 Index, float DeltaTime);
+
+};

--- a/Source/BlackSpace/UI/BSDamageNumberEntryWidget.cpp
+++ b/Source/BlackSpace/UI/BSDamageNumberEntryWidget.cpp
@@ -1,0 +1,27 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "UI/BSDamageNumberEntryWidget.h"
+#include "Components/TextBlock.h"
+
+void UBSDamageNumberEntryWidget::SetText(const FText& InText)
+{
+	if (DamageText) { DamageText->SetText(InText); }
+}
+
+void UBSDamageNumberEntryWidget::SetAlpha(float InAlpha)
+{
+    CurrentAlpha = FMath::Clamp(InAlpha, 0.f, 1.f);
+    if (DamageText)
+    {
+        FSlateColor SlateCol = DamageText->ColorAndOpacity;
+        FLinearColor C = SlateCol.GetSpecifiedColor();
+        C.A = CurrentAlpha;
+        DamageText->SetColorAndOpacity(C);
+    }
+}
+
+void UBSDamageNumberEntryWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+}

--- a/Source/BlackSpace/UI/BSDamageNumberEntryWidget.cpp
+++ b/Source/BlackSpace/UI/BSDamageNumberEntryWidget.cpp
@@ -6,7 +6,10 @@
 
 void UBSDamageNumberEntryWidget::SetText(const FText& InText)
 {
-	if (DamageText) { DamageText->SetText(InText); }
+	if (DamageText) 
+    { 
+        DamageText->SetText(InText); 
+    }
 }
 
 void UBSDamageNumberEntryWidget::SetAlpha(float InAlpha)
@@ -15,9 +18,9 @@ void UBSDamageNumberEntryWidget::SetAlpha(float InAlpha)
     if (DamageText)
     {
         FSlateColor SlateCol = DamageText->ColorAndOpacity;
-        FLinearColor C = SlateCol.GetSpecifiedColor();
-        C.A = CurrentAlpha;
-        DamageText->SetColorAndOpacity(C);
+        FLinearColor Color = SlateCol.GetSpecifiedColor();
+        Color.A = CurrentAlpha;
+        DamageText->SetColorAndOpacity(Color);
     }
 }
 

--- a/Source/BlackSpace/UI/BSDamageNumberEntryWidget.h
+++ b/Source/BlackSpace/UI/BSDamageNumberEntryWidget.h
@@ -1,0 +1,32 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "BSDamageNumberEntryWidget.generated.h"
+
+class UTextBlock;
+
+UCLASS()
+class BLACKSPACE_API UBSDamageNumberEntryWidget : public UUserWidget
+{
+	GENERATED_BODY()
+	
+protected:
+    UPROPERTY(meta = (BindWidget), BlueprintReadWrite)
+    TObjectPtr<UTextBlock> DamageText;
+
+protected:
+    float CurrentAlpha = 1.f;
+
+public:
+    UFUNCTION(BlueprintCallable)
+    void SetText(const FText& InText);
+
+    UFUNCTION(BlueprintCallable)
+    void SetAlpha(float InAlpha);
+
+protected:
+    virtual void NativeConstruct() override;
+};

--- a/Source/BlackSpace/UI/BSDamageNumberEntryWidget.h
+++ b/Source/BlackSpace/UI/BSDamageNumberEntryWidget.h
@@ -21,10 +21,7 @@ protected:
     float CurrentAlpha = 1.f;
 
 public:
-    UFUNCTION(BlueprintCallable)
     void SetText(const FText& InText);
-
-    UFUNCTION(BlueprintCallable)
     void SetAlpha(float InAlpha);
 
 protected:

--- a/Source/BlackSpace/UI/BSDamageNumberRootWidget.cpp
+++ b/Source/BlackSpace/UI/BSDamageNumberRootWidget.cpp
@@ -1,0 +1,133 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "UI/BSDamageNumberRootWidget.h"
+#include "Components/CanvasPanel.h"
+#include "Components/CanvasPanelSlot.h"
+
+#include "UI/BSDamageNumberEntryWidget.h"
+
+void UBSDamageNumberRootWidget::InitPool(int32 InitialSize)
+{
+	if (!Canvas || !EntryClass) 
+	{ 
+		return; 
+	}
+
+	Pool.Reset();
+
+	for (int32 i = 0; i < InitialSize; ++i)
+	{
+		AddOne();
+	}
+}
+
+int32 UBSDamageNumberRootWidget::BorrowEntry(const FText& DamageText)
+{
+	int32 Idx = FindFreeIndex();
+	if (Idx == INDEX_NONE)
+	{
+		Idx = AddOne();
+
+		if (Idx == INDEX_NONE) 
+		{ 
+			return INDEX_NONE; 
+		}
+	}
+
+	FEntrySlot& EntrySlot = Pool[Idx];
+	EntrySlot.InUse = true;
+	EntrySlot.Widget->SetText(DamageText);
+	EntrySlot.Widget->SetAlpha(1.f);
+	EntrySlot.Widget->SetRenderScale(FVector2D(1.f, 1.f));
+	EntrySlot.Widget->SetVisibility(ESlateVisibility::HitTestInvisible);
+	return Idx;
+}
+
+void UBSDamageNumberRootWidget::ReturnEntry(int32 Index)
+{
+	if (!Pool.IsValidIndex(Index)) 
+	{ 
+		return; 
+	}
+
+	FEntrySlot& EntrySlot = Pool[Index];
+	if (auto* TempSlot = Cast<UCanvasPanelSlot>(EntrySlot.Widget->Slot))
+	{
+		TempSlot->SetPosition(FVector2D(-10000.f, -10000.f));
+	}
+
+	EntrySlot.Widget->SetVisibility(ESlateVisibility::Collapsed);
+	EntrySlot.InUse = false;
+}
+
+void UBSDamageNumberRootWidget::UpdateEntry(int32 Index, const FVector2D& ScreenPos, float Alpha, float Scale, bool bVisible)
+{
+	if (!Pool.IsValidIndex(Index)) 
+	{ 
+		return; 
+	}
+
+	FEntrySlot& EntrySlot = Pool[Index];
+	if (!EntrySlot.InUse) 
+	{ 
+		return; 
+	}
+
+	if (auto* PanelSlot = Cast<UCanvasPanelSlot>(EntrySlot.Widget->Slot))
+	{
+		PanelSlot->SetPosition(ScreenPos);
+	}
+
+	EntrySlot.Widget->SetAlpha(Alpha);
+	EntrySlot.Widget->SetRenderScale(FVector2D(Scale, Scale));
+	EntrySlot.Widget->SetVisibility(bVisible ? ESlateVisibility::HitTestInvisible : ESlateVisibility::Collapsed);
+}
+
+void UBSDamageNumberRootWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+}
+
+int32 UBSDamageNumberRootWidget::AddOne()
+{
+	if (!Canvas || !EntryClass) 
+	{ 
+		return INDEX_NONE; 
+	}
+
+	UBSDamageNumberEntryWidget* EntryWidget = CreateWidget<UBSDamageNumberEntryWidget>(GetOwningPlayer(), EntryClass);
+	if (!EntryWidget) 
+	{ 
+		return INDEX_NONE; 
+	}
+
+	Canvas->AddChild(EntryWidget);
+	if (auto* PanelSlot = Cast<UCanvasPanelSlot>(EntryWidget->Slot))
+	{
+		PanelSlot->SetAutoSize(true);
+		PanelSlot->SetAlignment(FVector2D(0.5f, 0.5f));
+		PanelSlot->SetPosition(FVector2D(-10000.f, -10000.f)); // 화면 밖 대기
+	}
+	EntryWidget->SetVisibility(ESlateVisibility::Collapsed);
+
+	FEntrySlot EntrySlot;
+	EntrySlot.Widget = EntryWidget;
+	EntrySlot.InUse = false;
+
+	return Pool.Add(EntrySlot);
+}
+
+int32 UBSDamageNumberRootWidget::FindFreeIndex() const
+{
+	for (int32 i = 0; i < Pool.Num(); ++i)
+	{
+		if (!Pool[i].InUse) 
+		{ 
+			return i; 
+		}
+	}
+
+	return INDEX_NONE;
+}

--- a/Source/BlackSpace/UI/BSDamageNumberRootWidget.cpp
+++ b/Source/BlackSpace/UI/BSDamageNumberRootWidget.cpp
@@ -52,9 +52,9 @@ void UBSDamageNumberRootWidget::ReturnEntry(int32 Index)
 	}
 
 	FEntrySlot& EntrySlot = Pool[Index];
-	if (auto* TempSlot = Cast<UCanvasPanelSlot>(EntrySlot.Widget->Slot))
+	if (UCanvasPanelSlot* CanvasPanelSlot = Cast<UCanvasPanelSlot>(EntrySlot.Widget->Slot))
 	{
-		TempSlot->SetPosition(FVector2D(-10000.f, -10000.f));
+		CanvasPanelSlot->SetPosition(FVector2D(-10000.f, -10000.f));
 	}
 
 	EntrySlot.Widget->SetVisibility(ESlateVisibility::Collapsed);

--- a/Source/BlackSpace/UI/BSDamageNumberRootWidget.h
+++ b/Source/BlackSpace/UI/BSDamageNumberRootWidget.h
@@ -1,0 +1,57 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "BSDamageNumberRootWidget.generated.h"
+
+class UCanvasPanel;
+class UBSDamageNumberEntryWidget;
+
+USTRUCT()
+struct FEntrySlot
+{
+    GENERATED_BODY()
+
+    UPROPERTY() 
+    TObjectPtr<UBSDamageNumberEntryWidget> Widget;
+
+    bool InUse = false;
+};
+
+UCLASS()
+class BLACKSPACE_API UBSDamageNumberRootWidget : public UUserWidget
+{
+	GENERATED_BODY()
+	
+protected:
+    UPROPERTY(meta = (BindWidget), BlueprintReadWrite)
+    TObjectPtr<UCanvasPanel> Canvas;
+
+    UPROPERTY(EditAnywhere, Category = "DamageNumber | UI")
+    TSubclassOf<UBSDamageNumberEntryWidget> EntryClass;
+
+    UPROPERTY()
+    TArray<FEntrySlot> Pool;
+
+public:
+    /** 초기 풀 생성 */
+    void InitPool(int32 InitialSize);
+
+    /** 새로운 데미지 요청 시 하나 빌림(텍스트 초기화) */
+    int32 BorrowEntry(const FText& DamageText);
+
+    /** 반환(숨김/자리 비움) */
+    void ReturnEntry(int32 Index);
+
+    /** 매 프레임 갱신(서브시스템에서 호출) */
+    void UpdateEntry(int32 Index, const FVector2D& ScreenPos, float Alpha, float Scale, bool bVisible);
+
+protected:
+    virtual void NativeConstruct() override;
+
+private:
+    int32 AddOne();
+    int32 FindFreeIndex() const;
+};


### PR DESCRIPTION
## 관련 이슈 번호

#42 대미지 UI 표시

<br>


## 작업 내용 요약
- 구현한 기능이나 수정한 내용을 서술합니다.

적 AI가 피격당할 시 대미지 UI 표시

<br>


## 작업 상세 내용
- 주요 변경 사항과 설계 의도, 수정한 클래스나 시스템 구조에 대해 설명합니다.

각 적에 WidgetComponent 부착, 매 히트마다 Spawn/Destroy 하는 작업은 다음과 같은 문제점이 있었음

- 적 개체 수 증가 시 UMG 드로우/배치 비용 급증
- 잦은 생성/파괴로 인한 GC 및 메모리 단편화 문제

<br>

수정한 구조는 전역 UI 한 객체 + 풀링을 사용

- Draw Call 최소화
- 위젯 생성/파괴 최소화
- 오클루전 체크 옵션 지원


<br>


## 변경 파일 요약
- 주요 변경 파일과 역할을 간략히 정리합니다.

- UBSDamageNumberSubsystem : 전역 매니저
- UBSDamageNumberRootWidget : 전역 캔버스
- UBSDamageNumberEntryWidget : 텍스트 표시

<br>


## 궁금한 점 / 공부가 더 필요한 부분
- 작업 중 발생한 궁금한 점, 또는 이해가 잘 안되는 부분을 정리합니다.
